### PR TITLE
Adaptive image servlet addition to reference site

### DIFF
--- a/projects/reference-site/src/main/content/META-INF/vault/filter.xml
+++ b/projects/reference-site/src/main/content/META-INF/vault/filter.xml
@@ -5,4 +5,7 @@
 	</filter>
 	<filter root="/apps/sling" />
     <filter root="/etc/designs/aemtesting"/>
+
+    <filter root="/apps/dam"/>
+    <filter root="/etc/designs/reference-site"/>
 </workspaceFilter>

--- a/projects/reference-site/src/main/content/jcr_root/apps/dam/content/asseteditors/.content.xml
+++ b/projects/reference-site/src/main/content/jcr_root/apps/dam/content/asseteditors/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="sling:Folder"/>

--- a/projects/reference-site/src/main/content/jcr_root/apps/dam/content/asseteditors/image/.content.xml
+++ b/projects/reference-site/src/main/content/jcr_root/apps/dam/content/asseteditors/image/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="sling:Folder"/>

--- a/projects/reference-site/src/main/content/jcr_root/apps/dam/content/asseteditors/image/asseteditor.xml
+++ b/projects/reference-site/src/main/content/jcr_root/apps/dam/content/asseteditors/image/asseteditor.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+        jcr:primaryType="cq:Widget"
+        jcr:title="Image Asset Editor"
+        sling:resourceType="cq/ui/components/widget"
+        scene7="{Boolean}false"
+        scene7Type="image"
+        xtype="ref_site_asseteditor">
+    </jcr:root>

--- a/projects/reference-site/src/main/content/jcr_root/etc/designs/reference-site/dam-extensions/.content.xml
+++ b/projects/reference-site/src/main/content/jcr_root/etc/designs/reference-site/dam-extensions/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:ClientLibraryFolder"
+          categories="[cq.dam]"/>

--- a/projects/reference-site/src/main/content/jcr_root/etc/designs/reference-site/dam-extensions/js.txt
+++ b/projects/reference-site/src/main/content/jcr_root/etc/designs/reference-site/dam-extensions/js.txt
@@ -1,0 +1,4 @@
+#base=js
+AssetEditor.js
+widgets/smartimage4croppings.js
+

--- a/projects/reference-site/src/main/content/jcr_root/etc/designs/reference-site/dam-extensions/js/AssetEditor.js
+++ b/projects/reference-site/src/main/content/jcr_root/etc/designs/reference-site/dam-extensions/js/AssetEditor.js
@@ -1,0 +1,64 @@
+var AEM_REFSITE = AEM_REFSITE || {};
+
+AEM_REFSITE.AssetEditor = CQ.Ext.extend(CQ.dam.AssetEditor, {
+    /**
+     * Constructor
+     */
+    constructor : function(config) {
+        var imagepath = config.path;
+        var json = this.getCroppingsIds(config.path);
+        var buttons = {};
+
+        if(json.imageCroppings.length > 0){
+             buttons.bbarWest = [
+                    CQ.dam.AssetEditor.REFRESH_INFO,
+                    "->",
+                    {
+                        "text": CQ.I18n.getMessage("Image Croppings..."),
+                        "disabled": this.readOnly,
+                        "cls": "cq-btn-edit",
+                        "scope": this,
+                        "minWidth": CQ.dam.themes.AssetEditor.MIN_BUTTON_WIDTH,
+                        "handler": function() {
+                            var config = CQ.WCM.getDialogConfig({
+                                "name": "./original",
+                                "xtype": "smartimage4croppings",
+                                "cropParameter": "crop",
+                                "rotateParameter": "0",
+                                "disableFlush": true,
+                                "disableInfo": true,
+                                "json": this.getCroppingsIds(imagepath),
+                                "path": imagepath
+                            });
+
+                            var ae = this;
+                            config = CQ.Util.applyDefaults(config, {
+                                "title": CQ.I18n.getMessage("Image Croppings Editor"),
+                                "y": 50,
+                                "width": 800,
+                                "height": 600,
+                                "formUrl": this.pathEncoded + ".assetimage.html",
+                                "responseScope": this
+                            });
+                            var dialog = CQ.Util.build(config, true);
+                            dialog.loadContent(this.pathEncoded + "/jcr:content/renditions");
+                            dialog.show();
+                        }
+                    },
+                    CQ.dam.AssetEditor.EDIT_IMAGE
+                ];
+        }
+
+        config = CQ.Util.applyDefaults(config, buttons);
+        AEM_REFSITE.AssetEditor.superclass.constructor.call(this, config);
+    },
+
+    getCroppingsIds: function(path){
+      var request = ((window.XMLHttpRequest) ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP"));
+      request.open("GET", '/bin/services/core/public/allowedcroppings?path=' + path, false);
+      request.send(null);
+      return CQ.Ext.decode(request.responseText);
+    }
+});
+
+CQ.Ext.reg("ref_site_asseteditor", AEM_REFSITE.AssetEditor);

--- a/projects/reference-site/src/main/content/jcr_root/etc/designs/reference-site/dam-extensions/js/widgets/smartimage4croppings.js
+++ b/projects/reference-site/src/main/content/jcr_root/etc/designs/reference-site/dam-extensions/js/widgets/smartimage4croppings.js
@@ -1,6 +1,6 @@
-var NGS = NGS || {};
+var AEM_REFSITE = AEM_REFSITE || {};
 
-NGS.SmartImage4Croppings = CQ.Ext.extend(CQ.html5.form.SmartImage, {
+AEM_REFSITE.SmartImage4Croppings = CQ.Ext.extend(CQ.html5.form.SmartImage, {
     crops: {},
 
     constructor: function (config) {
@@ -29,11 +29,11 @@ NGS.SmartImage4Croppings = CQ.Ext.extend(CQ.html5.form.SmartImage, {
         var defaults = { "cropConfig": { "aspectRatios": aRatios } };
         config = CQ.Util.applyDefaults(config, defaults);
 
-        NGS.SmartImage4Croppings.superclass.constructor.call(this, config);
+        AEM_REFSITE.SmartImage4Croppings.superclass.constructor.call(this, config);
     },
 
     initComponent: function () {
-        NGS.SmartImage4Croppings.superclass.initComponent.call(this);
+        AEM_REFSITE.SmartImage4Croppings.superclass.initComponent.call(this);
 
         var imgTools = this.imageToolDefs;
         var cropTool;
@@ -185,4 +185,4 @@ NGS.SmartImage4Croppings = CQ.Ext.extend(CQ.html5.form.SmartImage, {
     }
 });
  
-CQ.Ext.reg("smartimage4croppings", NGS.SmartImage4Croppings);
+CQ.Ext.reg("smartimage4croppings", AEM_REFSITE.SmartImage4Croppings);

--- a/projects/reference-site/src/main/content/jcr_root/etc/designs/reference-site/dam-extensions/js/widgets/smartimage4croppings.js
+++ b/projects/reference-site/src/main/content/jcr_root/etc/designs/reference-site/dam-extensions/js/widgets/smartimage4croppings.js
@@ -1,0 +1,188 @@
+var NGS = NGS || {};
+
+NGS.SmartImage4Croppings = CQ.Ext.extend(CQ.html5.form.SmartImage, {
+    crops: {},
+
+    constructor: function (config) {
+        config = config || {};
+        var tObj = this;
+        var aRatios = {};
+
+        $.each(config.json.imageCroppings, function (key, value) {
+
+            var ratio = value.rect;
+            var rect = '';
+            var itemData = value.rect.split("/");
+
+            if(itemData.length > 1){
+                ratio = itemData[1];
+                rect = value.rect;
+            }
+
+            aRatios[value.id] = {
+                    "value": ratio,
+                    "text": value.id
+                };
+            tObj.crops[value.id] = { text: value.id, cords : rect};
+        });
+
+        var defaults = { "cropConfig": { "aspectRatios": aRatios } };
+        config = CQ.Util.applyDefaults(config, defaults);
+
+        NGS.SmartImage4Croppings.superclass.constructor.call(this, config);
+    },
+
+    initComponent: function () {
+        NGS.SmartImage4Croppings.superclass.initComponent.call(this);
+
+        var imgTools = this.imageToolDefs;
+        var cropTool;
+
+        if(imgTools){
+            for(var x = 0; x < imgTools.length; x++){
+                if(imgTools[x].toolId == 'smartimageCrop'){
+                    cropTool = imgTools[x];
+                    break;
+                }
+            }
+        }
+
+        if(!cropTool){
+            return;
+        }
+
+        var userInterface = cropTool.userInterface;
+
+        this.on("loadimage", function(){
+            var aRatios = userInterface.aspectRatioMenu.findByType("menucheckitem");
+
+            // Selection of the first cropping ID available in the croppings menu
+            // creation of the default cropping rectangle in case it is not available
+            aRatios[0].checked = true;
+            userInterface.toolbar.items.get("ratio").setText(
+                    userInterface.aspectRatioText + ": " + aRatios[0].text);
+            var initialValue = this.crops[aRatios[0].text].cords;
+
+
+            if(initialValue == ''){
+
+                var rect = "";
+                var size = cropTool.workingArea.originalImageSize;
+
+                if(size.height > size.width){
+                    var ratios = aRatios[0].value.split(',');
+                    var width = (parseInt(ratios[0]) * size.height) / parseInt(ratios[1]);
+                    rect = "0,0," + width + "," + size.height;
+                }else{
+                    var ratios = aRatios[0].value.split(',');
+                    var height = (parseInt(ratios[1]) * size.width) / parseInt(ratios[0]);
+                    rect = "0,0,"  + size.width + "," + height;
+                }
+
+                initialValue = rect + '/' + aRatios[0].value;
+            }
+            cropTool.initialValue = initialValue;
+
+            if(!aRatios){
+                return;
+            }
+
+            for(var x = 0; x < aRatios.length; x++){
+                aRatios[x].on('click', function(radio){
+                    var key = this.getCropKey(radio.text);
+
+                    if(!key){
+                        return;
+                    }
+
+                    if(this.crops[key].cords){
+                        this.setCoords(cropTool, this.crops[key].cords);
+                    }else{
+                        this.crops[key].cords = this.getRect(radio, userInterface);
+                    }
+                },this);
+
+                var key = this.getCropKey(aRatios[x].text);
+ 
+                if(key && this.dataRecord && this.dataRecord.data[key]){
+                    this.crops[key].cords = this.dataRecord.data[key];
+                }
+            }
+        });
+ 
+        cropTool.workingArea.on("contentchange", function(changeDef){
+            var aRatios = userInterface.aspectRatioMenu.findByType("menucheckitem");
+
+            var aRatioChecked;
+ 
+            if(aRatios){
+                for(var x = 0; x < aRatios.length; x++){
+                    if(aRatios[x].checked === true){
+                        aRatioChecked = aRatios[x];
+                        break;
+                    }
+                }
+            }
+ 
+            if(!aRatioChecked){
+                return;
+            }
+ 
+            var key = this.getCropKey(aRatioChecked.text);
+            this.crops[key].cords = this.getRect(aRatioChecked, userInterface);
+        }, this);
+    },
+ 
+    getCropKey: function(text){
+        for(var x in this.crops){
+            if(this.crops.hasOwnProperty(x)){
+                if(this.crops[x].text == text){
+                    return x;
+                }
+            }
+        }
+ 
+        return null;
+    },
+ 
+    getRect: function (radio, ui) {
+        var ratioStr = "";
+        var aspectRatio = radio.value;
+ 
+        if ((aspectRatio != null) && (aspectRatio != "0,0")) {
+            ratioStr = "/" + aspectRatio;
+        }
+
+        if (ui.cropRect == null) {
+            return ratioStr;
+        }
+ 
+        return ui.cropRect.x + "," + ui.cropRect.y + "," + (ui.cropRect.x + ui.cropRect.width) + ","
+            + (ui.cropRect.y + ui.cropRect.height) + ratioStr;
+    },
+ 
+    setCoords: function (cropTool, cords) {
+        cropTool.initialValue = cords;
+        cropTool.onActivation();
+    },
+
+    onBeforeSubmit: function() {
+        var requestparams = {};
+        requestparams["path"] = this.path;
+
+        $.each(this.crops, function (key, value) {
+            requestparams[value.text] = value.cords;
+        });
+
+        CQ.Ext.Ajax.request({
+            url: '/bin/services/core/public/setcroppings',
+            method: 'GET',
+            params: requestparams
+        });
+
+        this.reset();
+        return true;
+    }
+});
+ 
+CQ.Ext.reg("smartimage4croppings", NGS.SmartImage4Croppings);

--- a/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/AdaptiveImageService.java
+++ b/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/AdaptiveImageService.java
@@ -1,0 +1,77 @@
+package com.globant.aem.reference.site.images.adaptive.services;
+
+import java.util.List;
+
+public interface AdaptiveImageService {
+    
+    String FORMAT_WIDTH = "width:";
+    String FORMAT_MEDIA = "media:";
+    String FORMAT_PIXEL_DENSITY = "pixel-density:";
+
+    /**
+     * Returns the section of the repository in which these settings should be applied
+     * @return
+     */
+    String getSection();
+
+    /**
+     * True if the compression is enabled
+     * @return
+     */
+    Boolean getCompressionEnabled();
+
+    /**
+     * Compression factor for this section of the repository.
+     * @return
+     */
+    Float getCompressionFactor();
+
+    /**
+     * Returns the array of available widths in a plain string compatible with javascript.
+     * @return
+     */
+    String getAllowedWidthsString();
+
+    /**
+     * Returns the list of available widths in this section of the repository
+     * @return
+     */
+    List<String> getAllowedWidthsArray();
+
+    /**
+     * Returns the list of available croppings in this section of the repository
+     * @return
+     */
+    List<String> getAllowedCroppingsArray();
+    
+    /**
+     * Returns the list of supported images extension files
+     * @return
+     */
+    List<String> getSupportedImageTypes();
+
+    List<Format> getSupportedFormats();
+
+    boolean isMediaSet(List<Format> supportedFormats);
+
+    interface Format {
+        String getWidth();
+
+        String getMedia();
+
+        String[] getPixelDensity();
+
+        String getFmt();
+
+        void setFmt(String fmt);
+
+        void setWidth(String width);
+
+        void setMedia(String media);
+
+        void setPixelDensity(String pixelDensity);
+
+        String getFormatValue(String format, String key);
+    }
+
+}

--- a/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/AdaptiveImageServiceFacade.java
+++ b/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/AdaptiveImageServiceFacade.java
@@ -1,0 +1,14 @@
+package com.globant.aem.reference.site.images.adaptive.services;
+
+
+public interface AdaptiveImageServiceFacade {
+
+    /**
+     * Returns the instance of the server that matches with the received
+     * requestPath.
+     * 
+     * @param requestPath
+     * @return
+     */
+    AdaptiveImageService getServiceReference(String requestPath);
+}

--- a/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/AdaptiveImageServiceGlobalConfig.java
+++ b/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/AdaptiveImageServiceGlobalConfig.java
@@ -1,0 +1,6 @@
+package com.globant.aem.reference.site.images.adaptive.services;
+
+public interface AdaptiveImageServiceGlobalConfig {
+
+    public int getConcurrentThreads();
+}

--- a/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/impl/AdaptiveImageServiceFacadeImpl.java
+++ b/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/impl/AdaptiveImageServiceFacadeImpl.java
@@ -1,0 +1,59 @@
+package com.globant.aem.reference.site.images.adaptive.services.impl;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import java.util.regex.Pattern;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.ReferenceCardinality;
+import org.apache.felix.scr.annotations.ReferencePolicy;
+import org.apache.felix.scr.annotations.References;
+import org.apache.felix.scr.annotations.Service;
+import org.osgi.framework.ServiceReference;
+
+import com.globant.aem.reference.site.images.adaptive.services.AdaptiveImageService;
+import com.globant.aem.reference.site.images.adaptive.services.AdaptiveImageServiceFacade;
+
+@Component
+@Service
+@References({ @Reference(cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE, policy = ReferencePolicy.DYNAMIC, referenceInterface = AdaptiveImageService.class, name = "AdaptiveImageService") })
+public class AdaptiveImageServiceFacadeImpl implements AdaptiveImageServiceFacade {
+
+    private final Map<String, ServiceReference> adaptiveImageServiceConfigs = new HashMap<String, ServiceReference>();
+    private final List<String> adaptiveImageServicePatterns = new Vector<String>();
+
+    @Override
+    public AdaptiveImageService getServiceReference(String requestPath) {
+
+        for (String pattern : adaptiveImageServicePatterns) {
+            if (Pattern.matches(pattern, requestPath)) {
+                ServiceReference config = adaptiveImageServiceConfigs.get(pattern);
+                if (config == null)
+                    continue;
+                return (AdaptiveImageService) config.getBundle().getBundleContext().getService(config);
+            }
+        }
+        return null;
+    }
+
+    protected void bindAdaptiveImageService(ServiceReference ref) {
+        String sectionRegex = (String) ref.getProperty(AdaptiveImageServiceImpl.PROPERTY_SECTION);
+        adaptiveImageServiceConfigs.put(sectionRegex, ref);
+        adaptiveImageServicePatterns.add(sectionRegex);
+    }
+
+    protected void unbindAdaptiveImageService(ServiceReference ref) {
+        String sectionRegex = (String) ref.getProperty(AdaptiveImageServiceImpl.PROPERTY_SECTION);
+        adaptiveImageServiceConfigs.remove(sectionRegex);
+        for (Iterator<String> iterator = adaptiveImageServicePatterns.iterator(); iterator.hasNext();) {
+            String pattern = iterator.next();
+            if (pattern.equals(sectionRegex)) {
+                iterator.remove();
+            }
+        }
+    }
+}

--- a/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/impl/AdaptiveImageServiceGlobalConfigImpl.java
+++ b/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/impl/AdaptiveImageServiceGlobalConfigImpl.java
@@ -1,0 +1,38 @@
+package com.globant.aem.reference.site.images.adaptive.services.impl;
+
+import java.util.Map;
+
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.osgi.framework.BundleContext;
+
+import com.globant.aem.reference.site.images.adaptive.services.AdaptiveImageServiceGlobalConfig;
+
+@Service(value = AdaptiveImageServiceGlobalConfig.class)
+@Component(immediate = true, metatype = true, label = "Adaptive Image Service Global Config", description = "Provides Global Parameters for the Adaptive Image Service.")
+public class AdaptiveImageServiceGlobalConfigImpl implements
+        AdaptiveImageServiceGlobalConfig {
+
+    @Property(intValue = 10, label = "Allowed Concurrent Threads", description = "This is the maximum number of concurrent threads allowed for the service.")
+    public static final String PROPERTY_CONCURRENT_THREADS = "concurrent.threads";
+
+    private int concurrent_threads;
+
+    @Activate
+    protected void activate(final BundleContext bundleContext,
+            final Map<String, Object> properties) {
+        configureService(properties);
+    }
+
+    private void configureService(Map<String, Object> properties) {
+        concurrent_threads = PropertiesUtil.toInteger(properties.get(PROPERTY_CONCURRENT_THREADS), 10);
+    }
+
+    @Override
+    public int getConcurrentThreads() {
+        return this.concurrent_threads;
+    }
+}

--- a/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/impl/AdaptiveImageServiceImpl.java
+++ b/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/services/impl/AdaptiveImageServiceImpl.java
@@ -1,0 +1,228 @@
+package com.globant.aem.reference.site.images.adaptive.services.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.ConfigurationPolicy;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.PropertyUnbounded;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.osgi.framework.BundleContext;
+
+import com.globant.aem.reference.site.images.adaptive.services.AdaptiveImageService;
+
+@Component(immediate = true, configurationFactory = true, metatype = true, policy = ConfigurationPolicy.REQUIRE, label = "Adaptive Image Service", description = "Provides the rules applied to images in a section of the repository.")
+@Service(value = AdaptiveImageService.class)
+public class AdaptiveImageServiceImpl implements AdaptiveImageService {
+
+    @Property(label = "Section", description = "Section in which this configuration is applied.")
+    public static final String PROPERTY_SECTION = "section";
+
+    @Property(unbounded = PropertyUnbounded.ARRAY, label = "Supported Formats", description = "List of formats this component is permitted to generate. Order by min-width size"
+            + " when using min-width media queries, and by smallest width size when using max-width media queries")
+    public static final String PROPERTY_SUPPORTED_FORMATS = "image.supported.formats";
+
+    @Property(unbounded = PropertyUnbounded.ARRAY, label = "Supported Image types", description = "List of image types this component is permitted to generate. Referencing "
+            + "directly the image file extension")
+    public static final String PROPERTY_SUPPORTED_IMAGES_TYPES = "image.supported.type.images";
+
+    @Property(unbounded = PropertyUnbounded.ARRAY, label = "Supported Croppings", description = "List of croppings allowed in this section of the repository.")
+    public static final String PROPERTY_SUPPORTED_CROPPINGS = "image.supported.croppings";
+
+    @Property(boolValue = false, label = "Enable Compression", description = "Flag that indicates whether image compression is enabled.")
+    public static final String PROPERTY_ENABLE_COMPRESION = "image.enable.compression";
+
+    @Property(floatValue = 1F, label = "Compression Factor", description = "Compression factor that determines compression level in case it is enabled. Enter 1 for no compression.")
+    public static final String PROPERTY_COMPRESION_FACTOR = "image.compression.factor";
+
+    private String section;
+
+    private List<String> supportedFormatsArray;
+
+    private List<String> supportedImageTypes;
+
+    private List<String> supportedCroppingsArray;
+
+    private Boolean enabledCompression;
+
+    private Float compressionFactor;
+
+    @Activate
+    protected void activate(final BundleContext bundleContext,
+            final Map<String, Object> properties) {
+        configureService(properties);
+    }
+
+    private void configureService(Map<String, Object> properties) {
+        section = PropertiesUtil.toString(properties.get(PROPERTY_SECTION), "");
+        supportedFormatsArray = Arrays.asList(PropertiesUtil
+                .toStringArray(properties.get(PROPERTY_SUPPORTED_FORMATS)));
+
+        if (properties.get(PROPERTY_SUPPORTED_IMAGES_TYPES) != null){
+            supportedImageTypes = Arrays.asList(PropertiesUtil
+                    .toStringArray(properties
+                            .get(PROPERTY_SUPPORTED_IMAGES_TYPES)));
+        }
+        
+        if(supportedImageTypes == null || supportedImageTypes.size() == 0){
+            supportedImageTypes = new ArrayList<>(Arrays.asList("jpg", "png", "bmp", "jpeg"));
+        }
+
+        enabledCompression = PropertiesUtil.toBoolean(
+                properties.get(PROPERTY_ENABLE_COMPRESION), false);
+        compressionFactor = (float) PropertiesUtil.toDouble(properties
+                .get(AdaptiveImageServiceImpl.PROPERTY_COMPRESION_FACTOR), 0D);
+
+        if (properties.get(PROPERTY_SUPPORTED_CROPPINGS) != null)
+            supportedCroppingsArray = Arrays
+                    .asList(PropertiesUtil.toStringArray(properties
+                            .get(PROPERTY_SUPPORTED_CROPPINGS)));
+        else
+            supportedCroppingsArray = null;
+    }
+
+    @Override
+    public String getSection() {
+        return this.section;
+    }
+
+    @Override
+    public String getAllowedWidthsString() {
+        List<String> supportedWidthsArray = getAllowedWidthsArray();
+
+        // TODO: Removing the brackets for now just to avoid errors in the
+        // sites.
+        String supportedWidthsTemp = Arrays.toString(supportedWidthsArray
+                .toArray());
+        supportedWidthsTemp = supportedWidthsTemp.substring(1);
+        supportedWidthsTemp = supportedWidthsTemp.substring(0,
+                supportedWidthsTemp.length() - 1);
+
+        return supportedWidthsTemp;
+    }
+
+    @Override
+    public Boolean getCompressionEnabled() {
+        return enabledCompression;
+    }
+
+    @Override
+    public Float getCompressionFactor() {
+        return compressionFactor;
+    }
+
+    @Override
+    public List<String> getAllowedWidthsArray() {
+        List<String> result = new ArrayList<String>();
+        List<Format> supportedFormats = getSupportedFormats();
+        for (Format format : supportedFormats) {
+            result.add(format.getWidth());
+        }
+        return result;
+    }
+
+    @Override
+    public List<String> getAllowedCroppingsArray() {
+        return supportedCroppingsArray;
+    }
+
+    @Override
+    public List<Format> getSupportedFormats() {
+        List<Format> result = new ArrayList<AdaptiveImageService.Format>();
+        for (String formats : supportedFormatsArray) {
+            Format formatResult = new ImplFormat(formats);
+            result.add(formatResult);
+        }
+        return result;
+    }
+
+    public boolean isMediaSet(List<Format> supportedFormats) {
+        for (Format format : supportedFormats) {
+            if (StringUtils.isEmpty(format.getMedia())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> getSupportedImageTypes() {
+
+        return supportedImageTypes;
+    }
+
+    public class ImplFormat implements AdaptiveImageService.Format {
+
+        String width;
+        String media;
+        String[] pixelDensity;
+        String fmt;
+
+        public ImplFormat(String formats) {
+            String[] formatArray = formats.split("\\|");
+            for (String format : formatArray) {
+                if (format.startsWith(AdaptiveImageService.FORMAT_WIDTH)) {
+                    setWidth(getFormatValue(format,
+                            AdaptiveImageService.FORMAT_WIDTH));
+                } else if (format.startsWith(AdaptiveImageService.FORMAT_MEDIA)) {
+                    setMedia(getFormatValue(format,
+                            AdaptiveImageService.FORMAT_MEDIA));
+                } else if (format
+                        .startsWith(AdaptiveImageService.FORMAT_PIXEL_DENSITY)) {
+                    setPixelDensity(getFormatValue(format,
+                            AdaptiveImageService.FORMAT_PIXEL_DENSITY));
+                } else {
+                    setWidth(format);
+                }
+            }
+            setFmt(formats);
+        }
+
+        @Override
+        public String getWidth() {
+            return width;
+        }
+
+        public void setWidth(String width) {
+            this.width = width;
+        }
+
+        @Override
+        public String getMedia() {
+            return media;
+        }
+
+        public void setMedia(String media) {
+            this.media = media;
+        }
+
+        @Override
+        public String[] getPixelDensity() {
+            return (pixelDensity != null) ? pixelDensity : new String[] { "1" };
+        }
+
+        public void setPixelDensity(String pixelDensity) {
+            this.pixelDensity = pixelDensity.split(",");
+        }
+
+        public String getFormatValue(String format, String key) {
+            return format.substring(format.indexOf(key) + key.length());
+        }
+
+        public String getFmt() {
+            return fmt;
+        }
+
+        public void setFmt(String fmt) {
+            this.fmt = fmt;
+        }
+
+    }
+
+}

--- a/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/servlets/AdaptiveImageServlet.java
+++ b/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/servlets/AdaptiveImageServlet.java
@@ -1,0 +1,366 @@
+package com.globant.aem.reference.site.images.adaptive.servlets;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import javax.jcr.RepositoryException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.sling.SlingServlet;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.day.cq.commons.ImageHelper;
+import com.day.cq.commons.ImageResource;
+import com.day.cq.dam.api.Asset;
+import com.day.cq.wcm.commons.AbstractImageServlet;
+import com.day.cq.wcm.foundation.Image;
+import com.day.image.Layer;
+import com.globant.aem.reference.site.images.adaptive.services.AdaptiveImageService;
+import com.globant.aem.reference.site.images.adaptive.services.AdaptiveImageServiceFacade;
+import com.globant.aem.reference.site.images.adaptive.services.AdaptiveImageServiceGlobalConfig;
+
+@SlingServlet(resourceTypes = "sling/servlet/default", methods = "GET", selectors = { "adapt" }, extensions = { "jpg",
+        "png", "gif", "jpeg", "JPG", "PNG", "GIF", "JPEG" })
+@Properties({
+        @Property(name = "service.pid", value = "com.globant.aem.reference.site.images.adaptive.servlets.AdaptiveImageServlet", propertyPrivate = false),
+        @Property(name = "service.vendor", value = "Globant-Reference", propertyPrivate = false) })
+public class AdaptiveImageServlet extends AbstractImageServlet {
+
+    private final Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+    private static final long serialVersionUID = 3550347050814047028L;
+
+    private static int concurrentThreads = 0;
+
+    @Reference
+    private AdaptiveImageServiceFacade serviceFacade;
+
+    @Reference
+    private AdaptiveImageServiceGlobalConfig globalConfigs;
+
+    @Override
+    protected Layer createLayer(ImageContext imagecontext) throws RepositoryException, IOException {
+        return null;
+    }
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException,
+            IOException {
+
+        try {
+            synchronized (this) {
+                concurrentThreads++;
+                if (concurrentThreads > globalConfigs.getConcurrentThreads()) {
+                    response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+                    return;
+                }
+            }
+
+            String type;
+
+            try {
+                if (checkModifiedSince(request, response))
+                    return;
+            } catch (Exception e) {
+                LOG.warn("AdaptiveImageServlet Exception: ", e);
+            }
+
+            type = getImageType(request.getRequestPathInfo().getExtension().toLowerCase());
+
+            if (type == null) {
+                response.sendError(404, "Image type not supported");
+                return;
+            }
+            ImageContext context = new ImageContext(request, type);
+            Layer layer = null;
+            try {
+                layer = createLayer(context);
+            } catch (RepositoryException e) {
+                LOG.warn("AdaptiveImageServlet Exception: ", e);
+            }
+            if (layer != null)
+                applyDiff(layer, context);
+
+            writeLayer(request, response, context, layer);
+
+        } catch (RepositoryException e) {
+            LOG.warn("AdaptiveImageServlet Exception: ", e);
+        } finally {
+            concurrentThreads--;
+        }
+    }
+
+    @SuppressWarnings("static-access")
+    @Override
+    protected void writeLayer(SlingHttpServletRequest request, SlingHttpServletResponse response, ImageContext context,
+            Layer layer) throws IOException, RepositoryException {
+
+        AdaptiveImageService adaptiveImageService = serviceFacade.getServiceReference(request.getRequestPathInfo()
+                .getResourcePath());
+
+        if (adaptiveImageService == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        List<String> supportedWidthsArray = adaptiveImageService.getAllowedWidthsArray();
+        Boolean enableCompression = adaptiveImageService.getCompressionEnabled();
+        Float factor = adaptiveImageService.getCompressionFactor();
+        List<String> allowedCroppingsArray = adaptiveImageService.getAllowedCroppingsArray();
+
+        String selectors[] = request.getRequestPathInfo().getSelectors();
+
+        if ((selectors.length < 2 || !StringUtils.isNumeric(selectors[1]))) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        } else if (!supportedWidthsArray.contains(selectors[1])) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        String resourcePath = getResourcePath(request);
+        Resource resource = request.getResourceResolver().getResource(resourcePath);
+        if (resource == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+        Asset asset = resource.adaptTo(Asset.class);
+
+        String mimeType = asset.getMimeType();
+        if (ImageHelper.getExtensionFromType(mimeType) == null) {
+            // get default mime type
+            mimeType = "image/jpeg";
+        }
+
+        response.setContentType(mimeType);
+        BufferedImage srcImage = ImageIO.read(asset.getOriginal().getStream());
+
+        if (selectors.length == 4) {
+            if (allowedCroppingsArray == null) {
+                response.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            }
+
+            String croppingId = null;
+            String temp = selectors[3].toLowerCase() + ":";
+            for (String item : allowedCroppingsArray) {
+                if (item.toLowerCase().startsWith(temp)) {
+                    croppingId = item;
+                }
+            }
+
+            if (croppingId == null) {
+                // FIXME: REMOVE THE CODE BELLOW ADDED TO PROVIDE BACKWARDS
+                // COMPATIBILITY WITH SQRCROP SELECTOR AFTER NEXT DEPLOYMENT
+                if (temp.equals("sqrcrop:")) {
+                    croppingId = "sqrcrop:4:3";
+                } else {
+                    response.sendError(HttpServletResponse.SC_NOT_FOUND);
+                    return;
+                }
+            }
+
+            Resource croppingResource = resource.getChild("jcr:content/croppings/" + selectors[3].toLowerCase());
+            if (croppingResource != null) {
+                ValueMap croppingRect = croppingResource.adaptTo(ValueMap.class);
+                String x = croppingRect.get("x", String.class);
+                String y = croppingRect.get("y", String.class);
+                String w = croppingRect.get("w", String.class);
+                String h = croppingRect.get("h", String.class);
+
+                if (StringUtils.isNumeric(x) && StringUtils.isNumeric(y) && StringUtils.isNumeric(w)
+                        && StringUtils.isNumeric(h)) {
+                    srcImage = getImageCrop(srcImage, Integer.parseInt(x), Integer.parseInt(y), Integer.parseInt(w)
+                            - Integer.parseInt(x), Integer.parseInt(h) - Integer.parseInt(y));
+                } else {
+                    srcImage = cropImageWithCroppingId(srcImage, croppingId);
+                }
+            } else {
+                srcImage = cropImageWithCroppingId(srcImage, croppingId);
+            }
+        }
+
+        int multiplier = 1;
+
+        if (selectors.length > 2 && StringUtils.isNumeric(selectors[2])) {
+            multiplier = Integer.parseInt(selectors[2]);
+        }
+
+        int width = Integer.parseInt(selectors[1]);
+        width *= multiplier;
+
+        double ratio = ((double) width) / ((double) srcImage.getWidth());
+        int height = (int) (((double) srcImage.getHeight()) * ratio);
+
+        java.awt.Image img = srcImage.getScaledInstance(width, height, BufferedImage.SCALE_SMOOTH);
+
+        BufferedImage dstImage = srcImage.getColorModel().hasAlpha() ? new BufferedImage(width, height,
+                BufferedImage.TYPE_4BYTE_ABGR) : new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+
+        dstImage.getGraphics().drawImage(img, 0, 0, width, height, null);
+
+        if (enableCompression) {
+            ImageWriter writer = ImageIO.getImageWritersByMIMEType(mimeType).next();
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageOutputStream ios = ImageIO.createImageOutputStream(baos);
+
+            try {
+                ImageWriteParam param = writer.getDefaultWriteParam();
+                param.setCompressionMode(param.MODE_EXPLICIT);
+                param.setCompressionQuality(factor);
+
+                writer.setOutput(ios);
+                writer.write(null, new IIOImage(dstImage, null, null), param);
+
+                ByteArrayInputStream bai = new ByteArrayInputStream(baos.toByteArray());
+                dstImage = ImageIO.read(bai);
+            } catch (Exception ex) {
+                LOG.warn("AdaptiveImageServlet Exception: ", ex);
+            } finally {
+                ios.flush();
+                ios.close();
+                writer.dispose();
+            }
+        }
+
+        flushResponse(response, mimeType, dstImage);
+    }
+
+    /**
+     * Crops the image getting a centered cropping based on the aspect ratio
+     * assigned to the cropping id
+     * 
+     * @param srcImage
+     * @param croppingId
+     * @return
+     */
+    private BufferedImage cropImageWithCroppingId(BufferedImage srcImage, String croppingId) {
+        String[] items = croppingId.split(":");
+        if (items.length == 3 && StringUtils.isNumeric(items[1]) && StringUtils.isNumeric(items[2])) {
+            srcImage = getImageCrop(srcImage, Integer.parseInt(items[1]), Integer.parseInt(items[2]));
+        }
+        return srcImage;
+    }
+
+    /**
+     * Write an image in the response
+     *
+     * @param response
+     * @param mimeType
+     * @param dstImage
+     * @throws IOException
+     */
+    private void flushResponse(SlingHttpServletResponse response, String mimeType, BufferedImage dstImage)
+            throws IOException {
+        OutputStream os = response.getOutputStream();
+        String extension = ImageHelper.getExtensionFromType(mimeType);
+
+        try {
+            ImageIO.write(dstImage, extension, os);
+        } catch (Exception ex) {
+            LOG.warn("AdaptiveImageServlet Exception: ", ex);
+        } finally {
+            os.close();
+        }
+
+        response.flushBuffer();
+    }
+
+    /**
+     * Get a crop of an image based on its aspect ratio
+     * 
+     * @param source
+     *            Source image
+     * @param widthRatio
+     *            Aspect ratio width
+     * @param heightRatio
+     *            Aspect ratio height
+     * @return
+     */
+    private BufferedImage getImageCrop(BufferedImage source, int widthRatio, int heightRatio) {
+        int x, y, w, h;
+
+        if (widthRatio > heightRatio) {
+            x = 0;
+            w = source.getWidth();
+            h = (heightRatio * source.getWidth()) / widthRatio;
+            if (h > source.getHeight()) {
+                h = source.getHeight();
+            }
+            y = (source.getHeight() - h) / 2;
+        } else {
+            y = 0;
+            h = source.getHeight();
+            w = (widthRatio * source.getHeight()) / heightRatio;
+            if (w > source.getWidth()) {
+                w = source.getWidth();
+            }
+            x = (source.getWidth() - w) / 2;
+        }
+
+        source = getImageCrop(source, x, y, w, h);
+        return source;
+    }
+
+    /**
+     * Get a crop of an image based on cropping coordinates
+     * 
+     * @param source
+     *            Source image
+     * @param x
+     *            Cropping rectangle left coordinate
+     * @param y
+     *            Cropping rectangle right coordinate
+     * @param w
+     *            Cropping rectangle width
+     * @param h
+     *            Cropping rectangle height
+     * @return
+     */
+    private BufferedImage getImageCrop(BufferedImage source, int x, int y, int w, int h) {
+        source = source.getSubimage(x, y, w, h);
+        return source;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p/>
+     * Override default ImageResource creation to support assets
+     */
+    @Override
+    protected ImageResource createImageResource(Resource resource) {
+        return new Image(resource);
+    }
+
+    protected String getResourcePath(SlingHttpServletRequest request) {
+        String selectors[] = request.getRequestPathInfo().getSelectors();
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < selectors.length; i++) {
+            sb.append(selectors[i]).append(".");
+        }
+
+        return request.getRequestPathInfo().getResourcePath().replace(sb.toString(), "");
+    }
+}

--- a/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/servlets/GetAllowedCroppings.java
+++ b/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/servlets/GetAllowedCroppings.java
@@ -1,0 +1,111 @@
+package com.globant.aem.reference.site.images.adaptive.servlets;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.commons.json.JSONException;
+import org.apache.sling.commons.json.io.JSONWriter;
+
+import com.globant.aem.reference.site.images.adaptive.services.AdaptiveImageService;
+import com.globant.aem.reference.site.images.adaptive.services.AdaptiveImageServiceFacade;
+
+@Component(immediate = true, metatype = true, label = "Allowed Croppings Provider")
+@Service
+@Properties({
+        @Property(name = "sling.servlet.paths", value = { "/bin/services/core/public/allowedcroppings" }),
+        @Property(name = "sling.servlet.methods", value = { "GET" }) })
+public class GetAllowedCroppings extends SlingSafeMethodsServlet {
+
+    /**
+     * Serial Version ID
+     */
+    private static final long serialVersionUID = 1331999881285118556L;
+
+    @Reference
+    private AdaptiveImageServiceFacade serviceFacade;
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request,
+            final SlingHttpServletResponse response) throws ServletException,
+            IOException {
+
+        String path = request.getParameter("path");
+
+        Resource resource = request.getResourceResolver().resolve(path);
+        resource = resource.getChild("jcr:content/croppings");
+
+        HashMap<String, String> croppings = new HashMap<>();
+
+        if (resource != null) {
+            for (Resource child : resource.getChildren()) {
+                ValueMap croppingRect = child.adaptTo(ValueMap.class);
+                if (croppingRect != null) {
+                    String x = croppingRect.get("x", String.class);
+                    String y = croppingRect.get("y", String.class);
+                    String w = croppingRect.get("w", String.class);
+                    String h = croppingRect.get("h", String.class);
+                    croppings.put(child.getName(), x + "," + y + "," + w
+                            + "," + h + "/");
+                }
+            }
+
+        }
+
+        AdaptiveImageService adaptiveImageService = serviceFacade
+                .getServiceReference(path);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+
+        Writer out = response.getWriter();
+        JSONWriter writer = new JSONWriter(out);
+        try {
+            writer.object();
+            writer.key("imageCroppings");
+            writer.array();
+
+            if (adaptiveImageService != null
+                    && adaptiveImageService.getAllowedCroppingsArray() != null) {
+                List<String> allowedCroppings = adaptiveImageService
+                        .getAllowedCroppingsArray();
+
+                for (String cropping : allowedCroppings) {
+                    writer.object();
+                    String[] data = cropping.split(":");
+
+                    String rect = data[1] + "," + data[2];
+                    String ratio = rect;
+                    String key = data[0].toLowerCase();
+                    if (croppings.containsKey(key)) {
+                        rect = croppings.get(key) + rect;
+                    }
+                    writer.key("id").value(data[0]);
+                    writer.key("rect").value(rect);
+                    writer.key("ratio").value(ratio);
+                    writer.endObject();
+                }
+            }
+
+            writer.endArray();
+            writer.endObject();
+        } catch (JSONException e) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+    }
+}

--- a/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/servlets/SetCroppings.java
+++ b/projects/reference-site/src/main/java/com/globant/aem/reference/site/images/adaptive/servlets/SetCroppings.java
@@ -1,0 +1,92 @@
+package com.globant.aem.reference.site.images.adaptive.servlets;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Enumeration;
+
+import javax.servlet.ServletException;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+
+import com.globant.aem.reference.site.images.adaptive.services.AdaptiveImageServiceFacade;
+
+@Component(immediate = true, metatype = true, label = "Croppings Storage Servlet")
+@Service
+@Properties({
+        @Property(name = "sling.servlet.paths", value = { "/bin/services/core/public/setcroppings" }),
+        @Property(name = "sling.servlet.methods", value = { "GET" }) })
+public class SetCroppings extends SlingSafeMethodsServlet {
+
+    /**
+     * Serial Version ID
+     */
+    private static final long serialVersionUID = 1331999881285118556L;
+
+    @Reference
+    private AdaptiveImageServiceFacade serviceFacade;
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request,
+            final SlingHttpServletResponse response) throws ServletException,
+            IOException {
+
+        String path = request.getParameter("path");
+
+        ResourceResolver resourceResolver = request.getResourceResolver();
+        Resource imageResource = resourceResolver.resolve(path);
+
+        Resource contentResource = imageResource.getChild("jcr:content");
+        Resource croppingsResource = imageResource
+                .getChild("jcr:content/croppings");
+
+        if (croppingsResource == null) {
+            croppingsResource = resourceResolver.create(contentResource,
+                    "croppings", null);
+        }
+
+        Enumeration<?> names = request.getParameterNames();
+        while (names.hasMoreElements()) {
+            String name = (String) names.nextElement();
+            if (!name.equalsIgnoreCase("path")) {
+                String cords = request.getParameter(name);
+                String[] parts = cords.split("/");
+
+                if (parts.length == 2) {
+                    String[] rect = parts[0].split(",");
+                    if (rect.length == 4) {
+
+                        name = name.toLowerCase();
+                        Resource croppingIdResource = croppingsResource
+                                .getChild(name);
+                        if (croppingIdResource == null) {
+                            croppingIdResource = resourceResolver.create(
+                                    croppingsResource, name, null);
+                        }
+                        ModifiableValueMap properties = croppingIdResource
+                                .adaptTo(ModifiableValueMap.class);
+                        properties.put("x", rect[0]);
+                        properties.put("y", rect[1]);
+                        properties.put("w", rect[2]);
+                        properties.put("h", rect[3]);
+                    }
+                }
+            }
+
+            ModifiableValueMap properties = contentResource
+                    .adaptTo(ModifiableValueMap.class);
+            properties.put("jcr:lastModified", Calendar.getInstance());
+            
+            resourceResolver.commit();
+        }
+    }
+}


### PR DESCRIPTION
In order to test this feature please deploy the code, then go to "/system/console/configMgr" in the author instance, and create the following config:

![screenshot from 2015-09-09 18 43 53](https://cloud.githubusercontent.com/assets/5658684/9775064/c4d84c42-5722-11e5-8740-abef9e1aafe7.png)

Then take a valid image present in "/content/dam/geometrixx" and request it through a URL like the following:
http://localhost:4502/content/dam/geometrixx/portraits/yolanda_huggins.adapt.133.1.jpg
and verify the image has been optimized and its width is 133px

Also verify that the Asset Edition page shows "Image Croppings..." button on its classic UI as it is depicted in the image below, it should be present just for pictures matching with the regular expression in the config created above.

![screenshot from 2015-09-09 18 48 10](https://cloud.githubusercontent.com/assets/5658684/9775161/a32090a4-5723-11e5-8278-e79389ba54bf.png)

Then select different regions into the image for "sqrcrp" selector and check the corresponding results thorugh a URL like the following.

http://localhost:4502/content/dam/geometrixx/portraits/yolanda_huggins.adapt.133.1.sqrcrop.jpg

Not sure yet if integration tests could be added, in case it is possible I'll provide them through a new PR.

Thanks!